### PR TITLE
Polish docs and harden webhook verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
 # Paywaz Sample Integrations
 
-This repository contains lightweight, runnable examples demonstrating how to use the **Paywaz Public API** and the **Paywaz SDK**.
+Lightweight, runnable examples demonstrating the **Paywaz Public API** and the **Paywaz SDK**.
 
-✅ **JavaScript samples use the SDK package name:** `@paywaz/sdk`  
-✅ **Node 20+ recommended** for consistent execution
+- ✅ JavaScript samples use the SDK package name: `@paywaz/sdk`
+- ✅ Node 20+ recommended for consistent execution
 
 ---
 
 ## Samples
 
 ### JavaScript (Node 20+)
-- `javascript/payments` — create + fetch payment
+- `javascript/payments` — create and fetch payments
 - `javascript/webhooks-express` — webhook receiver + signature verification
+- `javascript/webhooks-node` — raw-body webhook receiver with secret rotation and replay protection
 - `javascript/nextjs-webhook` — framework-specific webhook handler
+- `javascript/simple-checkout.js` — minimal placeholder checkout flow
 
 ### Python
-- `python/payments` — create + fetch payment
-- `python/webhooks-fastapi` — webhook receiver + signature verification
+- `python/create-payment.py` — create a payment (placeholder flow)
+
+### cURL
+- `curl/basic-request.sh` — simple request example for quick testing and debugging
 
 ---
 
@@ -34,16 +38,14 @@ cp .env.example .env
 cd javascript/payments
 npm install
 npm run start
-
-### **cURL**
-Simple request examples for quick testing and debugging.
+```
 
 ---
 
 ## Requirements
 - API Key (coming soon)
-- Node.js 18+  
-- Python 3.10+  
+- Node.js 18+
+- Python 3.10+
 
 ---
 
@@ -57,13 +59,13 @@ Coming soon:
 ---
 
 ## Resources
-- API Reference: https://github.com/hellopaywaz/paywaz-public-api  
-- Docs: https://github.com/hellopaywaz/paywaz-docs  
-- Website: https://paywaz.com  
+- API Reference: https://github.com/hellopaywaz/paywaz-public-api
+- Docs: https://github.com/hellopaywaz/paywaz-docs
+- Website: https://paywaz.com
 
 ---
 
-⚠ These samples are for demonstration only. 
+⚠ These samples are for demonstration only.
 Do not use in production without proper security hardening.
 
 Paywaz.com LLC — *Zero-Fee Crypto-Native Payments.*

--- a/javascript/payments/README.md
+++ b/javascript/payments/README.md
@@ -1,43 +1,30 @@
 # Paywaz Payments (Node 20)
 
+Create and retrieve payments using the Paywaz SDK sample.
+
 ## Setup
+
 ```bash
 cp .env.example .env
-# fill PAYWAZ_API_KEY + PAYWAZ_DESTINATION
+# set PAYWAZ_API_KEY and PAYWAZ_DESTINATION (optional: PAYWAZ_AMOUNT, PAYWAZ_CURRENCY)
 npm install
-Create a payment
-bash
-Copy code
+```
+
+## Create a payment
+
+```bash
 npm run create
-Retrieve a payment
-bash
-Copy code
+```
+
+## Retrieve a payment
+
+Set `PAYWAZ_PAYMENT_ID` in `.env` (tip: use the ID printed by the create script), then run:
+
+```bash
 npm run get
-Notes:
+```
 
-Idempotency-Key is required for POST /payments.
+## Notes
 
-Send Paywaz-Version to pin behavior.
-
-yaml
-Copy code
-
----
-
-# 2) JavaScript Webhooks Example (Raw Body + HMAC verify)
-
-This is the “Stripe-grade” pattern: **raw request body**, constant-time compare, timestamp tolerance.
-
-## `paywaz-samples/javascript/webhooks-node/package.json`
-```json
-{
-  "name": "paywaz-samples-webhooks-node",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "start": "node server.mjs"
-  },
-  "dependencies": {
-    "dotenv": "^16.4.5"
-  }
-}
+- `Idempotency-Key` is required for `POST /payments`.
+- Send `Paywaz-Version` to pin API behavior.

--- a/javascript/webhooks-express/verify-signature.mjs
+++ b/javascript/webhooks-express/verify-signature.mjs
@@ -9,7 +9,10 @@ import crypto from "node:crypto";
  * ⚠️ If your OpenAPI uses different header names/format, adjust here once and all samples stay correct.
  */
 export function verifyPaywazWebhook({ rawBody, signatureHeader, secret, toleranceSeconds = 300 }) {
+  if (!secret) throw new Error("Missing webhook secret");
   if (!signatureHeader) throw new Error("Missing Paywaz-Signature header");
+
+  const normalizedBody = typeof rawBody === "string" ? rawBody : String(rawBody ?? "");
 
   const parts = Object.fromEntries(
     signatureHeader.split(",").map(kv => {
@@ -29,7 +32,7 @@ export function verifyPaywazWebhook({ rawBody, signatureHeader, secret, toleranc
     throw new Error("Timestamp outside tolerance (possible replay)");
   }
 
-  const signedPayload = `${timestamp}.${rawBody}`;
+  const signedPayload = `${timestamp}.${normalizedBody}`;
   const expected = crypto.createHmac("sha256", secret).update(signedPayload, "utf8").digest("hex");
 
   // constant-time compare

--- a/javascript/webhooks-node/README.md
+++ b/javascript/webhooks-node/README.md
@@ -1,59 +1,35 @@
 # Paywaz Webhooks (Node 20, raw-body verification)
 
-This sample implements spec-accurate webhook verification for:
+Spec-accurate webhook verification using the raw request body with:
 
 - `Paywaz-Timestamp: <unix_seconds>`
 - `Paywaz-Signature: v1=<hex>`
-- `signature = HMAC_SHA256(secret, `${timestamp}.${raw_body}`)`
-- Replay protection: reject if `|now - timestamp| > 300 seconds`
+- Signature: `HMAC_SHA256(secret, `${timestamp}.${raw_body}`)`
+- Replay protection: reject if `|now - timestamp| > tolerance`
 
 ## Setup
 
 ```bash
 cp .env.example .env
-# set PAYWAZ_WEBHOOK_SECRET
+# set PAYWAZ_WEBHOOK_SECRET (or PAYWAZ_WEBHOOK_SECRETS for rotation)
 npm install
 npm start
-Endpoint
-POST:
-http://localhost:8787/webhooks/payments
+```
 
-Local test (no Paywaz needed)
+## Endpoint
+
+`POST http://localhost:8787/webhooks/payments`
+
+## Local test (no Paywaz account required)
+
 Terminal A (server):
-
-bash
-Copy code
+```bash
 npm start
+```
+
 Terminal B (send a signed test event):
-
-bash
-Copy code
+```bash
 npm run test:send
-You should see ✅ Webhook verified in Terminal A.
+```
 
-yaml
-Copy code
-
----
-
-## ✅ Fixed root `paywaz-samples/README.md`
-
-Copy/paste **this entire file**:
-
-```md
-# Paywaz Samples
-
-Runnable integration examples for the Paywaz Public API.
-
-## JavaScript (Node 20)
-
-- `javascript/payments` — Create + retrieve payments (`POST /payments`, `GET /payments/{paymentId}`)
-- `javascript/webhooks-node` — Webhook receiver with raw-body signature verification (`POST /webhooks/payments`)
-
-## Notes
-
-- Payments require `Idempotency-Key`.
-- Webhooks must be verified using the **raw** request body with:
-  - `Paywaz-Timestamp`
-  - `Paywaz-Signature: v1=<hex>`
-- Webhooks should implement replay protection (reject if `|now - timestamp| > 300 seconds`).
+You should see `✅ Webhook verified` in Terminal A.

--- a/javascript/webhooks-node/server.mjs
+++ b/javascript/webhooks-node/server.mjs
@@ -1,4 +1,4 @@
-;import "dotenv/config";
+import "dotenv/config";
 import http from "node:http";
 import { verifyPaywazWebhook } from "./verify-signature.mjs";
 


### PR DESCRIPTION
## Summary
- Rewrite repository and sample READMEs for clear setup and usage guidance
- Harden webhook signature verification by requiring a secret and normalizing payloads
- Clean up webhook server import formatting

## Testing
- node --check javascript/webhooks-node/server.mjs
- node --check javascript/webhooks-express/verify-signature.mjs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447aabb0ac83238c71df76b3bbefe2)