### PR TITLE
Fix setup-node cache paths

### DIFF
--- a/.github/workflows/samples-ci.yml
+++ b/.github/workflows/samples-ci.yml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
 
       - name: Install root tooling
         run: npm ci


### PR DESCRIPTION
## Summary
- enable npm caching for samples CI with the repository lockfile path

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ecada627883238869799e674c1034)